### PR TITLE
refactor: auto detect external links

### DIFF
--- a/src/components/Link.svelte
+++ b/src/components/Link.svelte
@@ -3,19 +3,28 @@
 
   interface Props {
     href: string;
-    external?: boolean;
+    externalIcon?: boolean;
     muted?: boolean;
     underline?: boolean;
     children: Snippet;
   }
 
-  let { href, external = false, muted = false, underline = true, children }: Props = $props();
+  let { href, externalIcon = true, muted = false, underline = true, children }: Props = $props();
+
+  const domain = import.meta.env.SITE;
 </script>
 
-<!-- The <a> tag needs to be formatted like this to avoid weird whitespace issues -->
-<!-- See: https://github.com/withastro/astro/issues/6893 -->
-<a {href} class:external class:muted class:underline>
-  {@render children()}{#if external}<span class="external">&#x2197;</span>{/if}</a>
+<!-- We need the "externalIcon" boolean since we may not always to put the external icon on external links. -->
+<!-- For example, the "Powered By Vercel" badge. -->
+{#snippet externalLinkIcon()}
+  {#if externalIcon}<span class="external">&#x2197;</span>{/if}
+{/snippet}
+
+{#if !href.includes(domain) && !href.startsWith("/") && !href.startsWith("#")}
+  <a {href} class:muted class:underline>{@render children()}{@render externalLinkIcon()}</a>
+{:else}
+  <a {href} class:muted class:underline>{@render children()}</a>
+{/if}
 
 <style lang="scss">
   a {

--- a/src/data/blog/celebrating-three-years-of-catppuccin.mdx
+++ b/src/data/blog/celebrating-three-years-of-catppuccin.mdx
@@ -12,17 +12,16 @@ author:
   title: "Co-Owner"
   github: "sgoudham"
 ---
-import Link from "@components/Link.svelte"
 
 Welcome to Catppuccin's first (and very short) blog post! We'll try our best to
 publish important announcements, devlogs, general musings and more.
 
 ## Happy 3rd Anniversary
 
-Three years ago today, 5th December 2021, <Link
-href="https://github.com/pocco81" external>Pocco</Link> created the <Link
-href="https://github.com/catppuccin/catppuccin/releases/tag/v0.1.0"
-external>v0.1.0</Link> GitHub release.
+Three years ago today, 5th December 2021, [Pocco](https://github.com/pocco81)
+created the
+[v0.1.0](https://github.com/catppuccin/catppuccin/releases/tag/v0.1.0) GitHub
+release.
 
 Pocco is the creator of Catppuccin. Unfortunately, he doesn't have the time to
 contribute to this theme anymore, but he's still around now and then so make

--- a/src/data/blog/state-of-catppuccin-2024.mdx
+++ b/src/data/blog/state-of-catppuccin-2024.mdx
@@ -16,7 +16,7 @@ author:
 import Link from "@components/Link.svelte"
 
 Having felt quite inspired by Spotify Wrapped last year, I whipped up a short
-<Link href="https://github.com/catppuccin/community/blob/main/presentations/state-of-catppuccin-2023.pdf" external>presentation</Link>
+[presentation](https://github.com/catppuccin/community/blob/main/presentations/state-of-catppuccin-2023.pdf)
 to showcase statistics, highlight achievements and set loose goals for 2024.
 Everyone will be glad to hear that I won't be creating presentations anymore
 and instead use the blog to share this information.

--- a/src/data/links.ts
+++ b/src/data/links.ts
@@ -32,25 +32,21 @@ export const navigationLinks = [
     title: "Ports",
     target: "/ports",
     accent: "peach",
-    external: false,
   },
   {
     title: "Palette",
     target: "/palette",
     accent: "mauve",
-    external: false,
   },
   {
     title: "Community",
     target: "/community",
     accent: "green",
-    external: false,
   },
   {
     title: "Blog",
     target: "/blog",
     accent: "blue",
-    external: false,
   },
 ];
 
@@ -62,7 +58,6 @@ export const footerLinks = [
       {
         title: "Open Collective",
         target: "https://opencollective.com/catppuccin",
-        external: true,
       },
     ],
   },
@@ -78,7 +73,6 @@ export const footerLinks = [
     ].map((link) => ({
       title: link.name,
       target: link.url,
-      external: true,
     })),
   },
 ];

--- a/src/layouts/components/Footer.astro
+++ b/src/layouts/components/Footer.astro
@@ -14,11 +14,9 @@ import { footerLinks } from "@data/links";
           <strong>{categoryTitle}</strong>
         </p>
         <ul>
-          {categoryLinks.map(({ title, target, external }) => (
+          {categoryLinks.map(({ title, target }) => (
             <li>
-              <Link href={target} {external}>
-                {title}
-              </Link>
+              <Link href={target}>{title}</Link>
             </li>
           ))}
         </ul>
@@ -42,15 +40,14 @@ import { footerLinks } from "@data/links";
     <p>
       catppuccin.com is built and maintained by the community at <Link
         href="https://github.com/catppuccin/website"
-        muted
-        external>catppuccin/website</Link
+        muted>catppuccin/website</Link
       >.
     </p>
     <p>
       &copy; {new Date(Date.now()).getFullYear()} • <Link href="/licensing" muted>Licensing</Link>
     </p>
-    <Link href="https://vercel.com/?utm_source=Catppuccin&utm_campaign=oss">
-      <VercelBadge id="vercel" height={32} />
+    <Link href="https://vercel.com/?utm_source=Catppuccin&utm_campaign=oss" externalIcon={false}>
+      <VercelBadge id="vercel" height={40} />
     </Link>
   </div>
 

--- a/src/pages/blog/[id].astro
+++ b/src/pages/blog/[id].astro
@@ -42,7 +42,7 @@ const formattedDatePosted = new Date(post.data.datePosted).toLocaleDateString("e
     <PageIntro title={post.data.title}>
       <p class="article-summary">{post.data.summary}</p>
       <footer class="article-meta">
-        <Link href={`https://github.com/${post.data.author.github}`}>
+        <Link href={`https://github.com/${post.data.author.github}`} externalIcon={false}>
           <ProfilePicture username={post.data.author.github} size={64} wxh={56} />
         </Link>
         <div class="article-meta-text-wrap">
@@ -54,11 +54,10 @@ const formattedDatePosted = new Date(post.data.datePosted).toLocaleDateString("e
         </div>
       </footer>
     </PageIntro>
-    <Content />
+    <Content components={{ a: Link }} />
     <footer class="article-credit">
-      Hero image by <Link href={post.data.hero.source} external>{post.data.hero.author}</Link> modified with <Link
-        href="https://github.com/ozwaldorf/lutgen-rs"
-        external>lutgen-rs</Link
+      Hero image by <Link href={post.data.hero.source}>{post.data.hero.author}</Link> modified with <Link
+        href="https://github.com/ozwaldorf/lutgen-rs">lutgen-rs</Link
       >.
     </footer>
   </article>

--- a/src/pages/community/_components/UserCard.astro
+++ b/src/pages/community/_components/UserCard.astro
@@ -20,7 +20,7 @@ const isPlaceholder = (maintainersWithoutAvatars as string[]).includes(username)
 ---
 
 <div class="card-user" style={`--user-color: var(--${color})`}>
-  <Link {href} external>
+  <Link {href}>
     <ProfilePicture {username} size={256} wxh={128} />
     <br />
     <span class=`user-name ${isPlaceholder ? "placeholder" : ""}`>{name}</span></Link

--- a/src/pages/community/index.astro
+++ b/src/pages/community/index.astro
@@ -60,7 +60,7 @@ import Users, { type Person } from "./_components/Users.astro";
     <h3><TeamName team="userstyles" color="green">userstyles Staff</TeamName></h3>
     <p>
       Overseers of all userstyles in
-      <Link href="https://github.com/catppuccin/userstyles" external>catppuccin/userstyles</Link>.
+      <Link href="https://github.com/catppuccin/userstyles">catppuccin/userstyles</Link>.
       <strong>Responsible for all matters regarding userstyles.</strong>
     </p>
     <div class="user-grid">

--- a/src/pages/licensing/index.astro
+++ b/src/pages/licensing/index.astro
@@ -30,9 +30,8 @@ import Link from "@components/Link.svelte";
   <section class="illustration">
     <h2>The Illustration</h2>
     <p>
-      The homepage illustration is designed by <Link href="https://www.freepik.com/author/fullvector" external
-        >fullvector</Link
-      > on <Link href="https://www.freepik.com" external>freepik</Link> and has been modified for this website.
+      The homepage illustration is designed by <Link href="https://www.freepik.com/author/fullvector">fullvector</Link> on
+      <Link href="https://www.freepik.com">freepik</Link> and has been modified for this website.
     </p>
   </section>
 </Default>

--- a/src/pages/palette/index.astro
+++ b/src/pages/palette/index.astro
@@ -44,9 +44,9 @@ const toHsl = (hsl: ColorFormat["hsl"]) => {
       </ul>
       <p>
         If you'd like to use them for your own project, refer to our
-        <Link href=`${githubUrl}/catppuccin/blob/main/docs/style-guide.md` external>style guide</Link>
+        <Link href=`${githubUrl}/catppuccin/blob/main/docs/style-guide.md`>style guide</Link>
         for general use cases and guidelines. Additionally, you can find integrations with popular frameworks and tools in
-        <Link href=`${githubUrl}/palette` external>catppuccin/palette</Link>.
+        <Link href=`${githubUrl}/palette`>catppuccin/palette</Link>.
       </p>
     </p>
 

--- a/src/pages/ports/_components/PortGrid.svelte
+++ b/src/pages/ports/_components/PortGrid.svelte
@@ -18,7 +18,7 @@
         <p>Sorry, we couldn't find any ports matching your search :(</p>
         <p>
           You can request a port to be themed by raising a
-          <Link href="https://github.com/catppuccin/catppuccin/discussions/new?category=port-requests" external
+          <Link href="https://github.com/catppuccin/catppuccin/discussions/new?category=port-requests"
             >port request in catppuccin/catppuccin</Link
           >.
         </p>


### PR DESCRIPTION
This makes it much nicer to write MDX blog posts without the need of the `Link`
component as its now mapped to the `<a>` tag and can discern between
internal/links to show the external link icon or not.

There exists a boolean to override the icon, which is required when images are
used as links. So if a blog post needs a link which contains an image/svg and
we don't want the icon to show - then we need to import the Link component and
override it.

I'm happy trading off extra complexity in the `Link` component to avoid having
to specify `external` all across the codebase for every single external link we
want icons on.

_I know the real solution is to bin the entire icon but I like it... 😭_