### PR TITLE
feat: fluid anims

### DIFF
--- a/src/layouts/components/Footer.astro
+++ b/src/layouts/components/Footer.astro
@@ -88,9 +88,7 @@ import { footerLinks } from "@data/links";
       color: inherit;
       align-self: baseline;
 
-      &:hover {
-        cursor: pointer;
-      }
+      cursor: pointer;
     }
   </style>
 </footer>

--- a/src/pages/_components/LaptopIllustration.astro
+++ b/src/pages/_components/LaptopIllustration.astro
@@ -692,19 +692,21 @@
 
   svg * {
     transition:
-      transform 400ms cubic-bezier(0.34, 0.2, 0.56, 0.81),
-      opacity 400ms;
+      transform 700ms cubic-bezier(0.2, 0, 0, 1),
+      opacity 700ms;
   }
 
-  #coffee:hover,
-  #laptop:hover {
-    transform: translateY(-32px);
-  }
-
-  @media (prefers-reduced-motion) {
+  @media (hover: hover) {
     #coffee:hover,
     #laptop:hover {
-      transform: none;
+      transform: translateY(-32px);
+    }
+
+    @media (prefers-reduced-motion) {
+      #coffee:hover,
+      #laptop:hover {
+        transform: none;
+      }
     }
   }
 

--- a/src/pages/blog/_components/ArticleCard.astro
+++ b/src/pages/blog/_components/ArticleCard.astro
@@ -93,15 +93,42 @@ const formattedDatePosted = new Date(post.data.datePosted).toLocaleDateString("e
     overflow: clip;
     height: 100%;
 
-    transition: all 300ms ease-in-out;
+    transition:
+      opacity 225ms cubic-bezier(0, 0, 0, 1),
+      translate 225ms cubic-bezier(0, 0, 0, 1),
+      scale 225ms cubic-bezier(0, 0, 0, 1);
 
-    &:hover {
-      transform: scale(102%);
+    will-change: opacity, scale;
 
-      background-position: top right;
+    &::before {
+      content: "";
+      position: absolute;
+      inset: 0;
 
-      @media (prefers-reduced-motion) {
-        transform: none;
+      border-radius: inherit;
+      background-color: var(--surface0);
+
+      transition: opacity 200ms cubic-bezier(0.2, 0, 0, 1);
+      will-change: opacity;
+      opacity: 0;
+
+      z-index: -1;
+    }
+
+    &:hover,
+    &:focus-visible {
+      scale: 103%;
+
+      &::before {
+        opacity: 1;
+      }
+    }
+
+    &:active {
+      scale: 97.5%;
+
+      &::before {
+        opacity: 0.65;
       }
     }
 

--- a/src/pages/palette/index.astro
+++ b/src/pages/palette/index.astro
@@ -137,6 +137,12 @@ const toHsl = (hsl: ColorFormat["hsl"]) => {
 
     .color-list-entry {
       --__current-color: var(--current-color, var(--text));
+      @media (pointer: coarse) {
+        & > td {
+          --btn-target-size: 50px;
+          padding-block: calc(0 * var(--base-unit));
+        }
+      }
     }
 
     .color-name {

--- a/src/pages/ports/_components/PortCard.svelte
+++ b/src/pages/ports/_components/PortCard.svelte
@@ -5,9 +5,36 @@
   import PortMaintainers from "./PortMaintainers.svelte";
 
   let { port }: { port: PortWithIcons } = $props();
+
+  let isVisible = $state(false);
+  let element;
+
+  $effect(() => {
+    let observer = new IntersectionObserver(
+      (entries: HTMLElement[]) => {
+        for (let i = 0; i < entries.length; i++) {
+          const entry = entries[i];
+          isVisible = entry.isIntersecting;
+        }
+      },
+      {
+        threshold: 0.1,
+      },
+    );
+
+    if (element) {
+      observer.observe(element);
+    }
+
+    return () => {
+      if (observer) {
+        observer.disconnect();
+      }
+    };
+  });
 </script>
 
-<a href={port.repository.url} class="port-card">
+<a bind:this={element} href={port.repository.url} class="port-card" class:port-visible={isVisible}>
   <div class="port-header">
     <p class="port-name">{Array.isArray(port.name) ? port.name.join(", ") : port.name}</p>
     <Icon
@@ -43,35 +70,85 @@
     color: var(--subtext0);
     font-size: 1.6rem;
 
-    transition: all 300ms ease-in-out;
+    transition:
+      opacity 225ms cubic-bezier(0, 0, 0, 1),
+      translate 225ms cubic-bezier(0, 0, 0, 1),
+      scale 225ms cubic-bezier(0, 0, 0, 1);
 
-    &:hover {
-      transform: scale(102%);
+    will-change: opacity, scale;
 
-      background-position: top right;
+    &::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+
+      border-radius: inherit;
+      background-color: var(--surface0);
+
+      transition: opacity 200ms cubic-bezier(0.2, 0, 0, 1);
+      will-change: opacity;
+      opacity: 0;
+
+      z-index: -1;
+    }
+
+    &:focus-visible {
+      scale: 100%;
 
       text-decoration: none;
 
-      @media (prefers-reduced-motion) {
-        transform: none;
+      &::before {
+        opacity: 1;
       }
     }
 
-    p {
+    @media (hover: hover) {
+      &:hover {
+        scale: 105%;
+
+        text-decoration: none;
+
+        &::before {
+          opacity: 1;
+        }
+      }
+    }
+
+    &:focus {
+      text-decoration: none;
+    }
+
+    &:active {
+      scale: 95%;
+
+      &::before {
+        opacity: 0.65;
+      }
+    }
+
+    & {
+      opacity: 1;
+      translate: 0 0;
+    }
+    &:not(.port-visible) {
+      opacity: 0;
+      scale: 0.9;
+      translate: 0 10%;
+    }
+  }
+  .port-header {
+    @include utils.flex($gap: var(--space-sm));
+    flex-wrap: nowrap;
+    justify-content: space-between;
+    & > p {
       margin: 0;
       padding: 0;
     }
+  }
 
-    .port-header {
-      @include utils.flex($gap: var(--space-sm));
-      flex-wrap: nowrap;
-      justify-content: space-between;
-    }
-
-    .port-name {
-      color: var(--text);
-      font-size: 2rem;
-      font-weight: 600;
-    }
+  .port-name {
+    color: var(--text);
+    font-size: 2rem;
+    font-weight: 600;
   }
 </style>

--- a/src/pages/ports/index.astro
+++ b/src/pages/ports/index.astro
@@ -24,6 +24,11 @@ import PortCard from "./_components/PortCard.svelte";
     <div class="port-grid">
       {ports.map((port) => <PortCard {port} />)}
     </div>
+    <style>
+      .loader {
+        display: none;
+      }
+    </style>
   </noscript>
 
   <!-- TODO: Figure out a better general solution that doesn't involve defining SVGs as Svelte components or passing in nested Svelte 5 snippets/slots -->

--- a/src/styles/_buttons.scss
+++ b/src/styles/_buttons.scss
@@ -25,8 +25,44 @@
   font-weight: 500;
   color: var(--text);
 
-  transition: all 350ms ease-in-out;
   cursor: pointer;
+
+  transition:
+    opacity 225ms cubic-bezier(0, 0, 0, 1),
+    translate 225ms cubic-bezier(0, 0, 0, 1),
+    scale 150ms cubic-bezier(0, 0, 0, 1),
+    background 225ms cubic-bezier(0, 0, 0, 1);
+
+  will-change: opacity, scale;
+
+  // State layer
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background-color: currentColor;
+    transition: opacity 50ms linear;
+    opacity: 0;
+
+    will-change: opacity;
+  }
+
+  @media (hover: hover) {
+    &:hover {
+      // scale: 1.05;
+      &::after {
+        opacity: 0.08;
+      }
+    }
+  }
+
+  &:active {
+    scale: 0.95;
+    &::after {
+      opacity: 0.16;
+    }
+  }
 
   &-small {
     @include utils.containerPadding(xxs);
@@ -38,15 +74,20 @@
     background-color: transparent;
   }
 
-  &-transparent:hover,
-  &-transparent:focus {
-    background-color: color-mix(in srgb, transparent, var(--text) 10%);
-  }
-
   &-has-icon {
     display: flex;
     align-items: center;
     gap: var(--space-xs);
+  }
+
+  @media (pointer: coarse) {
+    & {
+      min-width: var(--btn-target-size, 44px);
+      min-height: var(--btn-target-size, 44px);
+    }
+    &-small {
+      @include utils.containerPadding(xxs-y);
+    }
   }
 
   &-peach {
@@ -113,9 +154,4 @@
     animation: btnFadeOut 350ms linear forwards;
     animation-delay: 500ms;
   }
-}
-
-.btn,
-.btn * {
-  transition: background-position 350ms ease-in-out;
 }

--- a/src/styles/_scaffolding.scss
+++ b/src/styles/_scaffolding.scss
@@ -6,8 +6,10 @@
 
 html {
   font-size: 62.5%;
-
   scroll-behavior: smooth;
+
+  color-scheme: light dark;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 
 @media (prefers-reduced-motion) {


### PR DESCRIPTION
Adds animations to port page on scroll, increases hover state contrast on tiles, button press state scale, and dynamic state layers that adapt to the content. Retimes some animations to not be longer in duration than needed, using the Fluent 2 motion principles .

There’s some unrelated code in the base to animations/state layers that I will split into a seperate PR.