### PR TITLE
perf: remove `key` for port-grid

### DIFF
--- a/src/pages/ports/_components/PortGrid.svelte
+++ b/src/pages/ports/_components/PortGrid.svelte
@@ -11,21 +11,19 @@
 </script>
 
 <div class="port-grid">
-  {#key portGrid}
-    {#if searchTerm && portGrid && portGrid.length === 0}
-      <div>
-        <p>Sorry, we couldn't find any ports matching your search :(</p>
-        <p>
-          You can request a port to be themed by raising a
-          <a href="https://github.com/catppuccin/catppuccin/discussions/new?category=port-requests"
-            >port request in catppuccin/catppuccin</a
-          >.
-        </p>
-      </div>
-    {:else if portGrid && portGrid.length > 0}
-      {#each portGrid as port (port.key)}
-        <PortCard {port} />
-      {/each}
-    {/if}
-  {/key}
+  {#if searchTerm && portGrid && portGrid.length === 0}
+    <div>
+      <p>Sorry, we couldn't find any ports matching your search :(</p>
+      <p>
+        You can request a port to be themed by raising a
+        <a href="https://github.com/catppuccin/catppuccin/discussions/new?category=port-requests"
+          >port request in catppuccin/catppuccin</a
+        >.
+      </p>
+    </div>
+  {:else if portGrid && portGrid.length > 0}
+    {#each portGrid as port (port.key)}
+      <PortCard {port} />
+    {/each}
+  {/if}
 </div>


### PR DESCRIPTION

I think this was causing the entire `port-grid` to be replaced, instead of just
the cards within it? I believe this increases performance as Svelte doesn't
keep destroying the entire container. Still need to confirm this.
