### PR TITLE
fix(ports): stop abusing browser history

### DIFF
--- a/src/pages/ports/_components/PortExplorer.svelte
+++ b/src/pages/ports/_components/PortExplorer.svelte
@@ -35,7 +35,7 @@
     } else {
       url.searchParams.set("q", searchTerm);
     }
-    window.history.pushState(null, "", url.toString());
+    window.history.replaceState(null, "", url.toString());
 
     clearTimeout(debounceTimeout);
     debounceTimeout = setTimeout(() => {


### PR DESCRIPTION

I'm surprised we haven't had an issue about this over the last year. This PR
makes sure that we don't keep pushing to the browser history when searching.
