### PR TITLE
feat(palette): overhaul colour tables

### DIFF
--- a/src/layouts/components/Head.astro
+++ b/src/layouts/components/Head.astro
@@ -39,4 +39,5 @@ const isProduction = import.meta.env.CATPPUCCIN_PROD;
 
 {enableViewTransition && <ClientRouter fallback="swap" />}
 
+<link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap" rel="stylesheet" />
 <title>{title}</title>

--- a/src/layouts/components/Head.astro
+++ b/src/layouts/components/Head.astro
@@ -39,5 +39,4 @@ const isProduction = import.meta.env.CATPPUCCIN_PROD;
 
 {enableViewTransition && <ClientRouter fallback="swap" />}
 
-<link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap" rel="stylesheet" />
 <title>{title}</title>

--- a/src/pages/palette/_components/ColorContextMenu.svelte
+++ b/src/pages/palette/_components/ColorContextMenu.svelte
@@ -46,12 +46,14 @@
     e.stopPropagation();
 
     const menuWidth = 240;
-    const menuHeight = 160;
     const cx = e.clientX + window.scrollX;
-    const cy = e.clientY + window.scrollY;
 
     x = e.clientX + menuWidth > window.innerWidth ? Math.max(0, cx - menuWidth) : cx;
-    y = e.clientY + menuHeight > window.innerHeight ? cy - menuHeight : cy;
+
+    if (window.innerWidth > 600) {
+      const cy = e.clientY + window.scrollY;
+      y = e.clientY + 160 > window.innerHeight ? cy - 160 : cy;
+    }
 
     openMenuId.set(id);
     ignoreNextClick = true;
@@ -90,6 +92,16 @@
   const handlePointerLeave = () => {
     clearTimeout(pressTimer);
   };
+
+  let isMobile = false;
+
+  if (typeof window !== 'undefined') {
+    const checkMobile = () => {
+      isMobile = window.innerWidth <= 600;
+    };
+    checkMobile();
+    window.addEventListener('resize', checkMobile);
+  }
 </script>
 
 <svelte:window onkeydown={(e) => e.key === "Escape" && openMenuId.set(null)} />
@@ -110,7 +122,11 @@
 {/if}
 
 {#if visible}
-  <div class="context-menu" style={`left: ${x}px; top: ${y}px`} onclick={(e) => e.stopPropagation()}>
+  <div
+    class="context-menu"
+    style={`left: ${isMobile ? '50%' : x + 'px'}; ${isMobile ? '' : `top: ${y}px`}`}
+    onclick={(e) => e.stopPropagation()}
+  >
     <div class="menu-header">
       <div class="menu-title">{name}</div>
       <button class="close-btn" onclick={() => openMenuId.set(null)}>✕</button>
@@ -206,13 +222,13 @@
     color: var(--red);
   }
 
-    .menu-items :global(button.success) {
-      background: var(--surface0);
-    }
+  .menu-items :global(button.success) {
+    background: var(--surface0);
+  }
 
-    .menu-items :global(button.failed) {
-      background: var(--surface0);
-    }
+  .menu-items :global(button.failed) {
+    background: var(--surface0);
+  }
 
   .menu-value {
     color: inherit;
@@ -245,9 +261,16 @@
 
   @media (max-width: 600px) {
     .context-menu {
-      font-size: 1.5rem;
+      position: fixed !important;
+      bottom: 2rem !important;
+      left: 2rem !important;
+      right: 2rem !important;
+      transform: none !important;
+      width: auto !important;
+      max-width: none;
+      border-radius: var(--border-radius-normal) var(--border-radius-normal) 0 0;
+      box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.4);
     }
-
     .menu-title {
       font-size: 1.75rem;
     }

--- a/src/pages/palette/_components/ColorContextMenu.svelte
+++ b/src/pages/palette/_components/ColorContextMenu.svelte
@@ -243,6 +243,24 @@
     }
   }
 
+  @media (max-width: 600px) {
+    .context-menu {
+      font-size: 1.5rem;
+    }
+
+    .menu-title {
+      font-size: 1.75rem;
+    }
+
+    .menu-items :global(button) {
+      font-size: 1.5rem;
+    }
+
+    .close-btn {
+      font-size: 2.5rem;
+    }
+  }
+
   @keyframes toast-in {
     from {
       opacity: 0;

--- a/src/pages/palette/_components/ColorContextMenu.svelte
+++ b/src/pages/palette/_components/ColorContextMenu.svelte
@@ -27,8 +27,14 @@
 
   const onContextMenu = (e: MouseEvent) => {
     e.stopPropagation();
-    x = e.clientX + window.scrollX;
-    y = e.clientY + window.scrollY;
+    const menuWidth = 240;
+    const menuHeight = 160;
+    const cx = e.clientX + window.scrollX;
+    const cy = e.clientY + window.scrollY;
+
+    x = e.clientX + menuWidth > window.innerWidth ? Math.max(0, cx - menuWidth) : cx;
+    y = e.clientY + menuHeight > window.innerHeight ? cy - menuHeight : cy;
+
     openMenuId.set(id);
   };
 </script>
@@ -41,7 +47,10 @@
 
 {#if visible}
   <div class="context-menu" style={`left: ${x}px; top: ${y}px`} onclick={(e) => e.stopPropagation()}>
-    <div class="menu-title">{name}</div>
+    <div class="menu-header">
+      <div class="menu-title">{name}</div>
+      <button class="close-btn" onclick={() => openMenuId.set(null)}>✕</button>
+    </div>
     <div class="menu-items">
       {#each [["HEX", hex], ["RGB", rgb], ["HSL", hsl], ["OKLCH", oklch]] as [label, value]}
         <CopyToClipboardIcon value={value}>
@@ -63,7 +72,8 @@
     z-index: 1000;
     display: flex;
     flex-direction: column;
-    min-width: 240px;
+    max-width: calc(100vw - 1rem);
+    min-width: 200px;
     padding: 0.5rem;
     border-radius: var(--border-radius-normal);
     background: var(--base);
@@ -77,9 +87,31 @@
     font-weight: bold;
     padding: 0.25rem 0.5rem 0.5rem;
     color: var(--text);
+    font-family: monospace;
+  }
+
+  .menu-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
     border-bottom: 1px solid var(--surface0);
     margin-bottom: 0.25rem;
-    font-family: monospace;
+  }
+
+  .close-btn {
+    background: none;
+    border: none;
+    border-radius: var(--border-radius-normal);
+    color: var(--subtext0);
+    cursor: pointer;
+    padding: 0.25rem 0.5rem;
+    font-size: 2rem;
+    line-height: 1;
+
+    &:hover {
+      color: var(--text);
+      background: var(--surface0);
+    }
   }
 
   .menu-items {
@@ -88,7 +120,12 @@
   }
 
   .menu-items :global(button) {
+    background: var(--base);
     text-align: left;
+
+    &:hover {
+      background: var(--surface0);
+    }
   }
 
   .menu-label {
@@ -104,6 +141,14 @@
   .menu-items :global(button.failed .menu-label) {
     color: var(--red);
   }
+
+    .menu-items :global(button.success) {
+      background: var(--surface0);
+    }
+
+    .menu-items :global(button.failed) {
+      background: var(--surface0);
+    }
 
   .menu-value {
     color: inherit;

--- a/src/pages/palette/_components/ColorContextMenu.svelte
+++ b/src/pages/palette/_components/ColorContextMenu.svelte
@@ -1,9 +1,22 @@
 <script module lang="ts">
   import { writable } from "svelte/store";
-  const openMenuId = writable<string | null>(null);
+  export const openMenuId = writable<string | null>(null);
+
+  let ignoreNextClick = false;
 
   if (typeof window !== "undefined") {
-    window.addEventListener("click", () => openMenuId.set(null));
+    window.addEventListener("click", (e: MouseEvent) => {
+      const menu = document.querySelector(".context-menu");
+
+      if (ignoreNextClick) {
+        ignoreNextClick = false;
+        return;
+      }
+
+      if (!menu?.contains(e.target as Node)) {
+        openMenuId.set(null);
+      }
+    });
   }
 </script>
 
@@ -25,8 +38,13 @@
   let x = $state(0);
   let y = $state(0);
 
-  const onContextMenu = (e: MouseEvent) => {
+  const LONG_PRESS_MS = 250;
+  let pressTimer: ReturnType<typeof setTimeout>;
+  let longPress = false;
+
+  const onContextMenu = (e: PointerEvent) => {
     e.stopPropagation();
+
     const menuWidth = 240;
     const menuHeight = 160;
     const cx = e.clientX + window.scrollX;
@@ -36,12 +54,39 @@
     y = e.clientY + menuHeight > window.innerHeight ? cy - menuHeight : cy;
 
     openMenuId.set(id);
+    ignoreNextClick = true;
+  };
+
+  const handlePointerDown = (e: PointerEvent) => {
+    longPress = false;
+
+    pressTimer = setTimeout(() => {
+      longPress = true;
+      onContextMenu(e);
+    }, LONG_PRESS_MS);
+  };
+
+  const handlePointerUp = async () => {
+    clearTimeout(pressTimer);
+
+    if (!longPress) {
+      await navigator.clipboard.writeText(hex);
+    }
+  };
+
+  const handlePointerLeave = () => {
+    clearTimeout(pressTimer);
   };
 </script>
 
 <svelte:window onkeydown={(e) => e.key === "Escape" && openMenuId.set(null)} />
 
-<div class="wrapper" onclick={onContextMenu}>
+<div
+  class="wrapper"
+  onpointerdown={handlePointerDown}
+  onpointerup={handlePointerUp}
+  onpointerleave={handlePointerLeave}
+>
   {@render children()}
 </div>
 

--- a/src/pages/palette/_components/ColorContextMenu.svelte
+++ b/src/pages/palette/_components/ColorContextMenu.svelte
@@ -66,11 +66,24 @@
     }, LONG_PRESS_MS);
   };
 
+  let toastState = $state<"hidden" | "success" | "failed">("hidden");
+  let toastTimer: ReturnType<typeof setTimeout>;
+
+  const showToast = (success: boolean) => {
+    toastState = success ? "success" : "failed";
+    clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => (toastState = "hidden"), 2000);
+  };
+
   const handlePointerUp = async () => {
     clearTimeout(pressTimer);
-
     if (!longPress) {
-      await navigator.clipboard.writeText(hex);
+      try {
+        await navigator.clipboard.writeText(hex);
+        showToast(true);
+      } catch {
+        showToast(false);
+      }
     }
   };
 
@@ -89,6 +102,12 @@
 >
   {@render children()}
 </div>
+
+{#if toastState !== "hidden"}
+  <div class="toast {toastState}">
+    {toastState === "success" ? "Hex copied!" : "Failed to copy"}
+  </div>
+{/if}
 
 {#if visible}
   <div class="context-menu" style={`left: ${x}px; top: ${y}px`} onclick={(e) => e.stopPropagation()}>
@@ -144,7 +163,7 @@
   }
 
   .close-btn {
-    background: none;
+    background: var(--mantle);
     border: none;
     border-radius: var(--border-radius-normal);
     color: var(--subtext0);
@@ -197,5 +216,41 @@
 
   .menu-value {
     color: inherit;
+  }
+
+  .toast {
+    position: fixed;
+    top: 1.5rem;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 2000;
+    padding: 0.75rem 2rem;
+    border-radius: var(--border-radius-normal);
+    background: var(--base);
+    font-family: monospace;
+    font-size: 2rem;
+    pointer-events: none;
+    animation: toast-in 0.2s ease forwards;
+
+    &.success {
+      color: var(--green);
+      border: 1px solid var(--green);
+    }
+
+    &.failed {
+      color: var(--red);
+      border: 1px solid var(--red);
+    }
+  }
+
+  @keyframes toast-in {
+    from {
+      opacity: 0;
+      transform: translateX(-50%) translateY(-0.5rem);
+    }
+    to {
+      opacity: 1;
+      transform: translateX(-50%) translateY(0);
+    }
   }
 </style>

--- a/src/pages/palette/_components/ColorContextMenu.svelte
+++ b/src/pages/palette/_components/ColorContextMenu.svelte
@@ -40,7 +40,7 @@
 </div>
 
 {#if visible}
-  <div class="context-menu" style={`left: ${x}px; top: ${y}px`}>
+  <div class="context-menu" style={`left: ${x}px; top: ${y}px`} onclick={(e) => e.stopPropagation()}>
     <div class="menu-title">{name}</div>
     <div class="menu-items">
       {#each [["HEX", hex], ["RGB", rgb], ["HSL", hsl], ["OKLCH", oklch]] as [label, value]}
@@ -69,6 +69,7 @@
     background: var(--base);
     border: 1px solid var(--surface0);
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+    text-align: left;
   }
 
   .menu-title {
@@ -86,10 +87,22 @@
     flex-direction: column;
   }
 
+  .menu-items :global(button) {
+    text-align: left;
+  }
+
   .menu-label {
     color: var(--subtext0);
     min-width: 3.5rem;
     display: inline-block;
+  }
+
+  .menu-items :global(button.success .menu-label) {
+    color: var(--green);
+  }
+
+  .menu-items :global(button.failed .menu-label) {
+    color: var(--red);
   }
 
   .menu-value {

--- a/src/pages/palette/_components/ColorContextMenu.svelte
+++ b/src/pages/palette/_components/ColorContextMenu.svelte
@@ -24,13 +24,14 @@
   import { type Snippet } from "svelte";
   import CopyToClipboardIcon from "./CopyToClipboardButton.svelte";
 
-  let { name, hex, rgb, hsl, oklch, children }: {
+  let { name, hex, rgb, hsl, oklch, children, flavorName }: {
     name: string;
     hex: string;
     rgb: string;
     hsl: string;
     oklch: string;
     children: Snippet;
+    flavorName?: string;
   } = $props();
 
   const id = hex;
@@ -128,7 +129,7 @@
     onclick={(e) => e.stopPropagation()}
   >
     <div class="menu-header">
-      <div class="menu-title">{name}</div>
+      <div class="menu-title">{flavorName ? `${flavorName} ${name}` : name}</div>
       <button class="close-btn" onclick={() => openMenuId.set(null)}>✕</button>
     </div>
     <div class="menu-items">
@@ -260,6 +261,10 @@
   }
 
   @media (max-width: 600px) {
+    .wrapper {
+      display: block;
+    }
+
     .context-menu {
       position: fixed !important;
       bottom: 2rem !important;

--- a/src/pages/palette/_components/ColorContextMenu.svelte
+++ b/src/pages/palette/_components/ColorContextMenu.svelte
@@ -226,11 +226,11 @@
     z-index: 2000;
     padding: 0.75rem 2rem;
     border-radius: var(--border-radius-normal);
-    background: var(--base);
+    background: var(--mantle);
     font-family: monospace;
     font-size: 2rem;
     pointer-events: none;
-    animation: toast-in 0.2s ease forwards;
+    animation: toast-in 0.2s ease forwards, toast-out 0.2s ease 1.8s forwards;
 
     &.success {
       color: var(--green);
@@ -251,6 +251,16 @@
     to {
       opacity: 1;
       transform: translateX(-50%) translateY(0);
+    }
+  }
+  @keyframes toast-out {
+    from {
+      opacity: 1;
+      transform: translateX(-50%) translateY(0);
+    }
+    to {
+      opacity: 0;
+      transform: translateX(-50%) translateY(0.5rem);
     }
   }
 </style>

--- a/src/pages/palette/_components/ColorContextMenu.svelte
+++ b/src/pages/palette/_components/ColorContextMenu.svelte
@@ -1,0 +1,98 @@
+<script module lang="ts">
+  import { writable } from "svelte/store";
+  const openMenuId = writable<string | null>(null);
+
+  if (typeof window !== "undefined") {
+    window.addEventListener("click", () => openMenuId.set(null));
+  }
+</script>
+
+<script lang="ts">
+  import { type Snippet } from "svelte";
+  import CopyToClipboardIcon from "./CopyToClipboardButton.svelte";
+
+  let { name, hex, rgb, hsl, oklch, children }: {
+    name: string;
+    hex: string;
+    rgb: string;
+    hsl: string;
+    oklch: string;
+    children: Snippet;
+  } = $props();
+
+  const id = hex;
+  let visible = $derived($openMenuId === id);
+  let x = $state(0);
+  let y = $state(0);
+
+  const onContextMenu = (e: MouseEvent) => {
+    e.stopPropagation();
+    x = e.clientX + window.scrollX;
+    y = e.clientY + window.scrollY;
+    openMenuId.set(id);
+  };
+</script>
+
+<svelte:window onkeydown={(e) => e.key === "Escape" && openMenuId.set(null)} />
+
+<div class="wrapper" onclick={onContextMenu}>
+  {@render children()}
+</div>
+
+{#if visible}
+  <div class="context-menu" style={`left: ${x}px; top: ${y}px`}>
+    <div class="menu-title">{name}</div>
+    <div class="menu-items">
+      {#each [["HEX", hex], ["RGB", rgb], ["HSL", hsl], ["OKLCH", oklch]] as [label, value]}
+        <CopyToClipboardIcon value={value}>
+          <span class="menu-label">{label}:</span>
+          <span class="menu-value">{value}</span>
+        </CopyToClipboardIcon>
+      {/each}
+    </div>
+  </div>
+{/if}
+
+<style lang="scss">
+  .wrapper {
+    display: contents;
+  }
+
+  .context-menu {
+    position: absolute;
+    z-index: 1000;
+    display: flex;
+    flex-direction: column;
+    min-width: 240px;
+    padding: 0.5rem;
+    border-radius: var(--border-radius-normal);
+    background: var(--base);
+    border: 1px solid var(--surface0);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  }
+
+  .menu-title {
+    text-transform: capitalize;
+    font-weight: bold;
+    padding: 0.25rem 0.5rem 0.5rem;
+    color: var(--text);
+    border-bottom: 1px solid var(--surface0);
+    margin-bottom: 0.25rem;
+    font-family: monospace;
+  }
+
+  .menu-items {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .menu-label {
+    color: var(--subtext0);
+    min-width: 3.5rem;
+    display: inline-block;
+  }
+
+  .menu-value {
+    color: inherit;
+  }
+</style>

--- a/src/pages/palette/_components/CopyToClipboardButton.svelte
+++ b/src/pages/palette/_components/CopyToClipboardButton.svelte
@@ -50,7 +50,7 @@
   };
 </script>
 
-<button class="btn btn-small btn-transparent {stateClass}" onclick={copyToClipboard}>
+<button class="btn btn-small btn-transparent {stateClass}" on:click={(e) => { e.stopPropagation(); e.preventDefault(); copyToClipboard(); }}>
   <span class="copy-icon">
     <svg width="12" height="12" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
       {#if stateClass == "success"}

--- a/src/pages/palette/_components/CopyToClipboardButton.svelte
+++ b/src/pages/palette/_components/CopyToClipboardButton.svelte
@@ -27,6 +27,27 @@
       stateClass = STATE.ready;
     }, 2000);
   };
+
+  let toastState = $state<"hidden" | "success" | "failed">("hidden");
+  let toastTimer: ReturnType<typeof setTimeout>;
+
+  const showToast = (success: boolean) => {
+    toastState = success ? "success" : "failed";
+    clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => (toastState = "hidden"), 2000);
+  };
+
+  const handlePointerUp = async () => {
+    clearTimeout(pressTimer);
+    if (!longPress) {
+      try {
+        await navigator.clipboard.writeText(hex);
+        showToast(true);
+      } catch {
+        showToast(false);
+      }
+    }
+  };
 </script>
 
 <button class="btn btn-small btn-transparent {stateClass}" onclick={copyToClipboard}>

--- a/src/pages/palette/index.astro
+++ b/src/pages/palette/index.astro
@@ -121,7 +121,7 @@ const toOklch = (oklch: ColorFormat["oklch"]) => {
 
     .color-list {
       display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));
+      grid-template-columns: repeat(auto-fill, minmax(8.5rem, 1fr));
       gap: var(--space-sm);
       margin-block-start: var(--space-md);
     }
@@ -149,7 +149,8 @@ const toOklch = (oklch: ColorFormat["oklch"]) => {
     }
 
     .color-name {
-      font-size: 1.7rem;
+      font-family: monospace;
+      font-size: 1.5rem;
       text-align: center;
       word-break: normal;
       overflow-wrap: normal;

--- a/src/pages/palette/index.astro
+++ b/src/pages/palette/index.astro
@@ -7,7 +7,8 @@ import Default from "@layouts/Default.astro";
 
 import PageIntro from "@components/PageIntro.astro";
 
-import CopyToClipboardIcon from "./_components/CopyToClipboardButton.svelte";
+// import CopyToClipboardIcon from "./_components/CopyToClipboardButton.svelte";
+import ColorContextMenu from "./_components/ColorContextMenu.svelte";
 import FlavorName from "./_components/FlavorName.astro";
 
 const toRgb = (rgb: ColorFormat["rgb"]) => {
@@ -62,46 +63,16 @@ const toOklch = (oklch: ColorFormat["oklch"]) => {
                   <FlavorName flavor={flavorName} bold={false} />
                 </h2>
               </summary>
-              <table class="color-list" cellspacing="0">
-                <thead>
-                  <tr class="color-list-header">
-                    <th>Color</th>
-                    <th>Hex</th>
-                    <th>RGB</th>
-                    <th>HSL</th>
-                    <th>OKLCH</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {Object.values(flavor.colors).map(({ hex, rgb, hsl, oklch, name }) => (
-                    <tr class="color-list-entry" style={`--current-color: ${hex}`}>
-                      <td class="color">
-                        <h5 class="color-name">{name}</h5>
-                      </td>
-                      <td class="color-hex">
-                        <CopyToClipboardIcon client:load value={hex}>
-                          {hex}
-                        </CopyToClipboardIcon>
-                      </td>
-                      <td class="color-rgb">
-                        <CopyToClipboardIcon client:load value={toRgb(rgb)}>
-                          {toRgb(rgb)}
-                        </CopyToClipboardIcon>
-                      </td>
-                      <td class="color-hsl">
-                        <CopyToClipboardIcon client:load value={toHsl(hsl)}>
-                          {toHsl(hsl)}
-                        </CopyToClipboardIcon>
-                      </td>
-                      <td class="color-oklch">
-                        <CopyToClipboardIcon client:load value={toOklch(oklch)}>
-                          {toOklch(oklch)}
-                        </CopyToClipboardIcon>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+              <div class="color-list">
+                {Object.values(flavor.colors).map(({ hex, rgb, hsl, oklch, name }) => (
+                  <ColorContextMenu client:load {name} {hex} rgb={toRgb(rgb)} hsl={toHsl(hsl)} oklch={toOklch(oklch)}>
+                    <div class="color-list-entry" style={`--current-color: ${hex}`}>
+                      <div class="color-swatch" />
+                      <span class="color-name">{name}</span>
+                    </div>
+                  </ColorContextMenu>
+                ))}
+              </div>
             </details>
           </div>
         ))
@@ -140,33 +111,54 @@ const toOklch = (oklch: ColorFormat["oklch"]) => {
     }
 
     .color-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--space-sm);
       margin-block-start: var(--space-md);
-      margin-inline: auto;
     }
 
     .color-list-entry {
-      --__current-color: var(--current-color, var(--text));
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      border-radius: var(--border-radius-normal);
+      gap: 1rem;
+      width: 8rem;
+      cursor: pointer;
+      padding: 2px;
+
+      &:hover {
+        background: var(--surface0);
+      }
+    }
+
+    .color-swatch {
+      width: 100%;
+      aspect-ratio: 1 / 1;
+      border-radius: var(--border-radius-normal);
+      background-color: var(--current-color);
+      border: 2px solid color-mix(in srgb, var(--mantle), var(--surface0) 50%);
     }
 
     .color-name {
-      position: relative;
+      font-size: 1.7rem;
+      text-align: center;
+      word-break: normal;
+      overflow-wrap: normal;
+    }
 
-      margin: 0;
-      padding: 0;
-      padding-inline-start: 3rem;
+    @media (max-width: 600px) {
+      .color-list {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(6rem, 1fr));
+      }
 
-      &::before {
-        content: "";
+      .color-list-entry {
+        width: 100%;
+      }
 
-        position: absolute;
-        left: 0;
-
-        height: 2rem;
-        aspect-ratio: 1 / 1;
-
-        border-radius: 9999px;
-        border: 1px solid color-mix(in srgb, var(--mantle), var(--surface0) 50%);
-        background-color: var(--__current-color);
+      .color-name {
+        font-size: 1.5rem;
       }
     }
   </style>

--- a/src/pages/palette/index.astro
+++ b/src/pages/palette/index.astro
@@ -66,7 +66,14 @@ const toOklch = (oklch: ColorFormat["oklch"]) => {
               <p class="flavor-hint">Click to copy hex • Hold for more formats</p>
               <div class="color-list">
                 {Object.values(flavor.colors).map(({ hex, rgb, hsl, oklch, name }) => (
-                  <ColorContextMenu client:load {name} {hex} rgb={toRgb(rgb)} hsl={toHsl(hsl)} oklch={toOklch(oklch)}>
+                  <ColorContextMenu
+                    client:load
+                    flavorName={flavorName}
+                    {name}
+                    {hex}
+                    rgb={toRgb(rgb)}
+                    hsl={toHsl(hsl)}
+                    oklch={toOklch(oklch)}>
                     <div class="color-list-entry" style={`--current-color: ${hex}`}>
                       <div class="color-swatch" />
                       <span class="color-name">{name}</span>

--- a/src/pages/palette/index.astro
+++ b/src/pages/palette/index.astro
@@ -111,8 +111,8 @@ const toOklch = (oklch: ColorFormat["oklch"]) => {
     }
 
     .color-list {
-      display: flex;
-      flex-wrap: wrap;
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));
       gap: var(--space-sm);
       margin-block-start: var(--space-md);
     }
@@ -123,7 +123,6 @@ const toOklch = (oklch: ColorFormat["oklch"]) => {
       align-items: center;
       border-radius: var(--border-radius-normal);
       gap: 1rem;
-      width: 8rem;
       cursor: pointer;
       padding: 2px;
 

--- a/src/pages/palette/index.astro
+++ b/src/pages/palette/index.astro
@@ -63,6 +63,7 @@ const toOklch = (oklch: ColorFormat["oklch"]) => {
                   <FlavorName flavor={flavorName} bold={false} />
                 </h2>
               </summary>
+              <p class="flavor-hint">Click to copy hex • Hold for more formats</p>
               <div class="color-list">
                 {Object.values(flavor.colors).map(({ hex, rgb, hsl, oklch, name }) => (
                   <ColorContextMenu client:load {name} {hex} rgb={toRgb(rgb)} hsl={toHsl(hsl)} oklch={toOklch(oklch)}>
@@ -89,6 +90,14 @@ const toOklch = (oklch: ColorFormat["oklch"]) => {
 
     summary {
       cursor: pointer;
+    }
+
+    .flavor-hint {
+      font-size: 1.5rem;
+      color: var(--subtext0);
+      margin-block-start: 0.25rem;
+      margin-block-end: 0;
+      font-family: monospace;
     }
 
     .flavor {

--- a/src/pages/palette/index.astro
+++ b/src/pages/palette/index.astro
@@ -137,7 +137,7 @@ const toOklch = (oklch: ColorFormat["oklch"]) => {
       aspect-ratio: 1 / 1;
       border-radius: var(--border-radius-normal);
       background-color: var(--current-color);
-      border: 2px solid color-mix(in srgb, var(--mantle), var(--surface0) 50%);
+      border: 2px solid color-mix(in srgb, var(--mantle), var(--text) 50%);
     }
 
     .color-name {


### PR DESCRIPTION
<p align="center">
	<img src="https://github.com/user-attachments/assets/76e8075a-2085-462d-aad3-bc5de0bfb084"/>
</p>


<details>
<summary>🌻 Latte</summary>
<img src="https://github.com/user-attachments/assets/fef099f8-e182-410b-a02a-eed9e3d11626"/>
</details>
<details>
<summary>🪴 Frappé</summary>
<img src="https://github.com/user-attachments/assets/012892c4-f526-4a46-90a6-cd1cbdc9707e"/>
</details>
<details>
<summary>🌺 Macchiato</summary>
<img src="(https://github.com/user-attachments/assets/bcd936db-5632-4972-b1e3-e66850c383f1"/>
</details>
<details>
<summary>🌿 Mocha</summary>
<img src="https://github.com/user-attachments/assets/db632775-4b38-4895-93a4-0dcf281f06fd"/>
</details>