### PR TITLE
fix: add missing comma to oklch function syntax

### DIFF
--- a/src/pages/palette/index.astro
+++ b/src/pages/palette/index.astro
@@ -17,7 +17,7 @@ const toHsl = (hsl: ColorFormat["hsl"]) => {
   return `hsl(${Math.round(hsl.h)}deg, ${Math.round(hsl.s * 100)}%, ${Math.round(hsl.l * 100)}%)`;
 };
 const toOklch = (oklch: ColorFormat["oklch"]) => {
-  return `oklch(${Math.round(oklch.l * 100)}%, ${Math.round(oklch.c * 100)}% ${Math.round(oklch.h)}deg)`;
+  return `oklch(${Math.round(oklch.l * 100)}%, ${Math.round(oklch.c * 100)}%, ${Math.round(oklch.h)}deg)`;
 };
 ---
 


### PR DESCRIPTION
- Closes #346 

This is the simplest fix.

Another consideration is to use modern syntax, omitting the commas, as outlined in the issue.

```
oklch(L C H [/ A])
```