### PR TITLE
fix: use MDN specified OKLCH syntax, remove multiplier and Math.round

### DIFF
--- a/src/pages/palette/index.astro
+++ b/src/pages/palette/index.astro
@@ -17,7 +17,7 @@ const toHsl = (hsl: ColorFormat["hsl"]) => {
   return `hsl(${Math.round(hsl.h)}deg, ${Math.round(hsl.s * 100)}%, ${Math.round(hsl.l * 100)}%)`;
 };
 const toOklch = (oklch: ColorFormat["oklch"]) => {
-  return `oklch(${Math.round(oklch.l * 100)}%, ${Math.round(oklch.c * 100)}%, ${Math.round(oklch.h)}deg)`;
+  return `oklch(${oklch.l.toFixed(3)} ${oklch.c.toFixed(3)} ${oklch.h.toFixed(3)})`;
 };
 ---
 


### PR DESCRIPTION
While the official `catppuccin/palette` generates the correct OKLCH values, the `toOklch` helper on the website is generating wrong values.

- Correct OKLCH syntax is `oklch(x y z)` and not `oklch(x,y,z)`.
- OKLCH is very sensitive to values specially the Hue value, rounding it can cause color mismatch
- C (chroma) is not [0,1], it more like [0,0.4] practically and percentages don't just convert 1:1,so browsers will convert x% to (x/100) * 0.4 instead of just (x/100)


Official MDN docs https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/color_value/oklch