### PR TITLE
fix(licensing): fix typo and restore missing space before freepik link

### DIFF
--- a/src/pages/licensing/index.astro
+++ b/src/pages/licensing/index.astro
@@ -21,7 +21,7 @@ import Default from "@layouts/Default.astro";
       The Website is provided »<b>as is</b>«, without warranty of any kind, express or implied, including but not
       limited to the warranties of merchantability, fitness for a particular purpose and noninfringement. In no event
       shall the authors or copyright holders be liable for any claim, damages or other liability, whether in an action
-      of contract, tort or otherwise, araising from, out of or in connection with the Website or the use or other
+      of contract, tort or otherwise, arising from, out of or in connection with the Website or the use or other
       dealings in the Website.
     </p>
   </section>
@@ -29,7 +29,9 @@ import Default from "@layouts/Default.astro";
   <section class="illustration">
     <h2>The Illustration</h2>
     <p>
-      The homepage illustration is designed by <a href="https://www.freepik.com/author/fullvector">fullvector</a> on
+      The homepage illustration is designed by <a href="https://www.freepik.com/author/fullvector">fullvector</a> on{
+        " "
+      }
       <a href="https://www.freepik.com">freepik</a> and has been modified for this website.
     </p>
   </section>


### PR DESCRIPTION
## What

Two fixes on the `/licensing` page:

1. `araising` → `arising` — typo in the MIT license text.
2. Restored the missing space before the freepik link.

## Why the `{" "}`

Astro 7 changed the default for `compressHTML` to `'jsx'`. Whitespace
and line breaks around elements are now stripped following JSX rules,
so the newline that previously rendered as a space between `on` and the
freepik link is removed. The docs recommend adding such whitespace
explicitly via `{" "}`.

Raw HTML before:

```
fullvector</a> on<a href="https://www.freepik.com" ...>freepik</a>
```

After:

```
fullvector</a> on <a href="https://www.freepik.com" ...>freepik</a>
```

## Notes

I checked the rest of the built output for the same pattern — this is
the only affected spot. Matches on `/community` are icons spaced by CSS,
not by markup, and render fine.

Prettier expands `{" "}` onto three lines here. Happy to use a
different construct if you prefer something tidier.